### PR TITLE
Fade in on spawn

### DIFF
--- a/lib/Player.js
+++ b/lib/Player.js
@@ -6,6 +6,8 @@ class Player {
     this.height = 24;
     this.color = color;
     this.lives = 3;
+    this.alive = true;
+    this.timer = 0;
   }
 
   draw(c) {
@@ -28,6 +30,22 @@ class Player {
         this.y = 0;
       }
   }
+
+  respawn(){
+    if (this.alive === false) {
+      this.x = 100;
+      this.y = 350;
+      if (this.timer <= 200) {
+        this.color = 'black'
+        this.timer++
+      } else {
+        this.color = 'pink';
+        this.alive = true;
+        this.timer = 0;
+      }
+    }
+ 
+  };
 } 
 
 module.exports = Player;

--- a/lib/Player.js
+++ b/lib/Player.js
@@ -31,17 +31,16 @@ class Player {
       }
   }
 
-  respawn(){
+  respawn(spawnX, spawnY){
     if (this.alive === false) {
 
       if (this.timer <= 200) {
-        this.x=100;
-        this.y=350;
+        this.x=350;
+        this.y=400 - this.height;
         this.width = 0;
         this.timer++
       } else {
         this.width = 24;
-        this.color = 'pink';
         this.alive = true;
         this.timer = 0;
       }

--- a/lib/Player.js
+++ b/lib/Player.js
@@ -33,12 +33,14 @@ class Player {
 
   respawn(){
     if (this.alive === false) {
-      this.x = 100;
-      this.y = 350;
+
       if (this.timer <= 200) {
-        this.color = 'black'
+        this.x=100;
+        this.y=350;
+        this.width = 0;
         this.timer++
       } else {
+        this.width = 24;
         this.color = 'pink';
         this.alive = true;
         this.timer = 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,11 +97,8 @@ function playerToPlayerCollision() {
             } else if (crossWidth >-(crossHeight) === false) {
               console.log('p2 top')
               p1.y -= 50;
-              p2.color = 'red'
               gameManager.p2Lives -= 1;
-              p2.x = 100;
-              p2.y = 350;
-              // p1.y += 10;
+              p2.alive = false;
               console.log(gameManager.p2Lives);
           }
         }
@@ -118,6 +115,7 @@ function animate() {
     player.draw(c);
     player.teleport(canvasWidth);
     player.gravity(gravity);
+    player.respawn()
   })
   platformPlayerCollision();
   playerToPlayerCollision();

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,9 @@ function playerToPlayerCollision() {
           if (crossWidth > crossHeight) {
             if (crossWidth > (-crossHeight) === true ) {
               console.log('p2 bottom')
-              p2.y -= 10;
+              p2.y -= 50;
+              gameManager.p1Lives -= 1;
+              p1.alive = false;
             } else if (crossWidth > (-crossHeight) === false) {
               console.log('p2 left')
               p2.x += 2;


### PR DESCRIPTION
Check this suuuuper sick function I made to delay the appearance of either character after death... 

- I added a this.alive value to the player and created a respawn() function thats being called with the rest of the animate stuff. So basically it's checking to see if the player is alive===true every frame regen. If its false, (which is kicked off in our top and bottom collision when that happens), it starts a timer thats initialized at zero. While that is less than 200 the players width is zero and the timer is incremented...
- As soon as its over 200 the width is returned, this.alive=true and the timer is reset.

- Also, I implemented p1s death too just so I could test for both characters respawn, hope you don't mind but it was basically a copy/pasta just into the p2 bottoms being touched.